### PR TITLE
Fixed startup crash

### DIFF
--- a/8vim/src/main/java/inc/flide/vim8/MainInputMethodService.java
+++ b/8vim/src/main/java/inc/flide/vim8/MainInputMethodService.java
@@ -100,7 +100,7 @@ public class MainInputMethodService extends InputMethodService {
     }
 
     public Map<List<FingerPosition>, KeyboardAction> buildKeyboardActionMap() {
-        return InputMethodServiceHelper.initializeKeyboardActionMap(getResources());
+        return InputMethodServiceHelper.initializeKeyboardActionMap(getResources(), getApplicationContext());
     }
 
     public void sendText(String text) {

--- a/8vim/src/main/java/inc/flide/vim8/keyboardHelpers/InputMethodServiceHelper.java
+++ b/8vim/src/main/java/inc/flide/vim8/keyboardHelpers/InputMethodServiceHelper.java
@@ -1,5 +1,6 @@
 package inc.flide.vim8.keyboardHelpers;
 
+import android.content.Context;
 import android.content.res.Resources;
 import android.renderscript.ScriptGroup;
 
@@ -18,7 +19,7 @@ import inc.flide.vim8.structures.FingerPosition;
 
 public class InputMethodServiceHelper {
 
-    public static Map<List<FingerPosition>, KeyboardAction> initializeKeyboardActionMap(Resources resources) {
+    public static Map<List<FingerPosition>, KeyboardAction> initializeKeyboardActionMap(Resources resources, Context context) {
 
         Map<List<FingerPosition>, KeyboardAction> mainKeyboardActionsMap = new HashMap<>();
         mainKeyboardActionsMap = addToKeyboardActionsMap(
@@ -34,7 +35,7 @@ public class InputMethodServiceHelper {
                 resources,
                 R.raw.special_core_gestures);
 
-        int languageLayoutResourceId = loadTheSelectedLanguageLayout(resources);
+        int languageLayoutResourceId = loadTheSelectedLanguageLayout(resources, context);
         mainKeyboardActionsMap = addToKeyboardActionsMap(
                 mainKeyboardActionsMap,
                 resources,
@@ -43,8 +44,8 @@ public class InputMethodServiceHelper {
         return mainKeyboardActionsMap;
     }
 
-    private static int loadTheSelectedLanguageLayout(Resources resources) {
-        String currentLanguageLayout = SharedPreferenceHelper.getInstance(null).getString("current_language_layout", resources.getResourceName(R.raw.en_eight_pen_original));
+    private static int loadTheSelectedLanguageLayout(Resources resources, Context context) {
+        String currentLanguageLayout = SharedPreferenceHelper.getInstance(context).getString("current_language_layout", resources.getResourceName(R.raw.en_eight_pen_original));
 
         String packageName = currentLanguageLayout.substring(0, currentLanguageLayout.indexOf(':'));
         String defType = currentLanguageLayout.substring(currentLanguageLayout.indexOf(':')+1, currentLanguageLayout.indexOf('/'));

--- a/8vim/src/main/java/inc/flide/vim8/preferences/SharedPreferenceHelper.java
+++ b/8vim/src/main/java/inc/flide/vim8/preferences/SharedPreferenceHelper.java
@@ -10,6 +10,8 @@ public class SharedPreferenceHelper {
     private static SharedPreferenceHelper singleton = null;
 
     public static SharedPreferenceHelper getInstance(Context context){
+        //These two ifs should be probably swapped as it can still return null
+        //when singleton is null.
         if (context == null) {
             return singleton;
         }


### PR DESCRIPTION
I am not sure if I should create issue first, but since I have already fixed it I decided to make it PR.

This fixes crash that happens every time system requests keyboard but 8VIM is not running in background (and thus `SharedPreferenceHelper`s singleton is still `null` 

This happens on all my test devices:
Samsung Galaxy J500FN (android 6.0.1) and
Xiaomy Redmi Note 5 PRO (Android 10, lineage OS 17.1)
(I can make test runs on two other devices if necessary)

After these changes it works fine on both of my test devices.

I am not sure if this is the correct approach to this problem as I am not that familiar with codebase yet. If it should be handled differently then just take this as Bug report.