### PR TITLE
Make it (mostly) work with Fabularium

### DIFF
--- a/8vim/src/main/java/inc/flide/vim8/MainInputMethodService.java
+++ b/8vim/src/main/java/inc/flide/vim8/MainInputMethodService.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.inputmethodservice.InputMethodService;
 import android.os.IBinder;
 import android.os.SystemClock;
+import android.service.autofill.CharSequenceTransformation;
+import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
@@ -174,6 +176,15 @@ public class MainInputMethodService extends InputMethodService {
     public void sendKey(int keyEventCode, int flags) {
         sendDownAndUpKeyEvent(keyEventCode, getShiftLockFlag() | getCapsLockFlag() | modifierFlags | flags);
         clearModifierFlags();
+    }
+
+    public void delete() {
+        CharSequence sel = inputConnection.getSelectedText(0);
+        if (TextUtils.isEmpty(sel)) {
+            inputConnection.deleteSurroundingText(1, 0);
+        } else {
+            inputConnection.commitText("", 0);
+        }
     }
 
 

--- a/8vim/src/main/java/inc/flide/vim8/keyboardActionListners/KeypadActionListener.java
+++ b/8vim/src/main/java/inc/flide/vim8/keyboardActionListners/KeypadActionListener.java
@@ -3,6 +3,7 @@ package inc.flide.vim8.keyboardActionListners;
 import android.view.HapticFeedbackConstants;
 import android.view.KeyEvent;
 import android.view.View;
+import android.view.inputmethod.InputConnection;
 
 import inc.flide.vim8.MainInputMethodService;
 import inc.flide.vim8.R;
@@ -126,6 +127,9 @@ public class KeypadActionListener {
                     break;
                 case KeyEvent.KEYCODE_ENTER:
                     mainInputMethodService.commitImeOptionsBasedEnter();
+                    break;
+                case KeyEvent.KEYCODE_DEL:
+                    mainInputMethodService.delete();
                     break;
                 default:
                     mainInputMethodService.sendKey(primaryCode, keyFlags);

--- a/8vim/src/main/java/inc/flide/vim8/views/mainKeyboard/XpadView.java
+++ b/8vim/src/main/java/inc/flide/vim8/views/mainKeyboard/XpadView.java
@@ -45,7 +45,6 @@ public class XpadView extends View {
     private PointF circleCenter;
     private Circle circle;
     private final Dimension keypadDimension = new Dimension();
-    private ConstraintLayout.LayoutParams xPadLayoutParams;
 
     private int backgroundColor;
     private int foregroundColor;
@@ -128,16 +127,8 @@ public class XpadView extends View {
         int parentWidth = MeasureSpec.getSize(widthMeasureSpec);
         int parentHeight = MeasureSpec.getSize(heightMeasureSpec);
 
-        int width = (parentWidth / 6) * 5;
-        if (xPadLayoutParams == null) {
-            xPadLayoutParams = new ConstraintLayout.LayoutParams(width, parentHeight);
-        } else {
-            xPadLayoutParams.width = width;
-            xPadLayoutParams.height = parentHeight;
-        }
-
-        keypadDimension.setWidth(xPadLayoutParams.width);
-        keypadDimension.setHeight(xPadLayoutParams.height);
+        keypadDimension.setWidth((parentWidth/6) *5);
+        keypadDimension.setHeight(parentHeight);
 
         setMeasuredDimension(keypadDimension.getWidth(), keypadDimension.getHeight());
     }

--- a/8vim/src/main/res/raw/en_eight_pen_original.xml
+++ b/8vim/src/main/res/raw/en_eight_pen_original.xml
@@ -1,163 +1,192 @@
 <keyboardActionMap>
     <!--{NO_TOUCH, INSIDE_CIRCLE, TOP, LEFT, BOTTOM, RIGHT}-->
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_A</inputKey>
+        <inputString>a</inputString>
+        <inputCapsLockString>A</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;TOP;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_R</inputKey>
+        <inputString>r</inputString>
+        <inputCapsLockString>R</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;TOP;LEFT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_X</inputKey>
+        <inputString>x</inputString>
+        <inputCapsLockString>X</inputCapsLockString>
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_Y</inputKey>
+        <inputString>y</inputString>
+        <inputCapsLockString>Y</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;RIGHT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_B</inputKey>
+        <inputString>b</inputString>
+        <inputCapsLockString>B</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;RIGHT;BOTTOM;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_P</inputKey>
+        <inputString>p</inputString>
+        <inputCapsLockString>P</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;RIGHT;BOTTOM;LEFT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_Q</inputKey>
+        <inputString>q</inputString>
+        <inputCapsLockString>Q</inputCapsLockString>
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_S</inputKey>
+        <inputString>s</inputString>
+        <inputCapsLockString>S</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;LEFT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_D</inputKey>
+        <inputString>d</inputString>
+        <inputCapsLockString>D</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;LEFT;BOTTOM;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_G</inputKey>
+        <inputString>g</inputString>
+        <inputCapsLockString>G</inputCapsLockString>
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_T</inputKey>
+        <inputString>t</inputString>
+        <inputCapsLockString>T</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;TOP;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_C</inputKey>
+        <inputString>c</inputString>
+        <inputCapsLockString>C</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;TOP;RIGHT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_Z</inputKey>
+        <inputString>z</inputString>
+        <inputCapsLockString>Z</inputCapsLockString>
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_I</inputKey>
+        <inputString>i</inputString>
+        <inputCapsLockString>I</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;BOTTOM;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_H</inputKey>
+        <inputString>h</inputString>
+        <inputCapsLockString>H</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;BOTTOM;RIGHT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_J</inputKey>
+        <inputString>j</inputString>
+        <inputCapsLockString>J</inputCapsLockString>
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_E</inputKey>
+        <inputString>e</inputString>
+        <inputCapsLockString>E</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;LEFT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_L</inputKey>
+        <inputString>l</inputString>
+        <inputCapsLockString>L</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;LEFT;TOP;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_K</inputKey>
+        <inputString>k</inputString>
+        <inputCapsLockString>K</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_O</inputKey>
+        <inputString>o</inputString>
+        <inputCapsLockString>O</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;RIGHT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_U</inputKey>
+        <inputString>u</inputString>
+        <inputCapsLockString>U</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;RIGHT;TOP;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_V</inputKey>
+        <inputString>v</inputString>
+        <inputCapsLockString>V</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_W</inputKey>
+        <inputString>w</inputString>
+        <inputCapsLockString>W</inputCapsLockString>
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_N</inputKey>
+        <inputString>n</inputString>
+        <inputCapsLockString>N</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;BOTTOM;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_M</inputKey>
+        <inputString>m</inputString>
+        <inputCapsLockString>M</inputCapsLockString>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;BOTTOM;LEFT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_F</inputKey>
+        <inputString>f</inputString>
+        <inputCapsLockString>F</inputCapsLockString>
     </keyboardAction>
 
     <!--Capital Characters-->
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;TOP;LEFT;BOTTOM;RIGHT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_A</inputKey>
+        <inputString>A</inputString>
+        <inputCapsLockString>a</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;TOP;LEFT;BOTTOM;RIGHT;TOP;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_R</inputKey>
+        <inputString>R</inputString>
+        <inputCapsLockString>r</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;TOP;LEFT;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_X</inputKey>
+        <inputString>X</inputString>
+        <inputCapsLockString>x</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
@@ -170,58 +199,65 @@
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;RIGHT;BOTTOM;LEFT;TOP;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_Y</inputKey>
+        <inputString>Y</inputString>
+        <inputCapsLockString>y</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;RIGHT;BOTTOM;LEFT;TOP;RIGHT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_B</inputKey>
+        <inputString>B</inputString>
+        <inputCapsLockString>b</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;RIGHT;BOTTOM;LEFT;TOP;RIGHT;BOTTOM;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_P</inputKey>
+        <inputString>P</inputString>
+        <inputCapsLockString>p</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;RIGHT;BOTTOM;LEFT;TOP;RIGHT;BOTTOM;LEFT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_Q</inputKey>
+        <inputString>Q</inputString>
+        <inputCapsLockString>q</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;LEFT;BOTTOM;RIGHT;TOP;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_S</inputKey>
+        <inputString>S</inputString>
+        <inputCapsLockString>s</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;LEFT;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_D</inputKey>
+        <inputString>D</inputString>
+        <inputCapsLockString>d</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;TOP;LEFT;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_G</inputKey>
+        <inputString>G</inputString>
+        <inputCapsLockString>g</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
@@ -233,25 +269,28 @@
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;TOP;RIGHT;BOTTOM;LEFT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_T</inputKey>
+        <inputString>T</inputString>
+        <inputCapsLockString>t</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;TOP;RIGHT;BOTTOM;LEFT;TOP;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_C</inputKey>
+        <inputString>C</inputString>
+        <inputCapsLockString>c</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;TOP;RIGHT;BOTTOM;LEFT;TOP;RIGHT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_Z</inputKey>
+        <inputString>Z</inputString>
+        <inputCapsLockString>z</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
@@ -264,25 +303,28 @@
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_I</inputKey>
+        <inputString>I</inputString>
+        <inputCapsLockString>i</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_H</inputKey>
+        <inputString>H</inputString>
+        <inputCapsLockString>h</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;LEFT;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;RIGHT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_J</inputKey>
+        <inputString>J</inputString>
+        <inputCapsLockString>j</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
@@ -295,25 +337,28 @@
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;LEFT;TOP;RIGHT;BOTTOM;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_E</inputKey>
+        <inputString>E</inputString>
+        <inputCapsLockString>e</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;LEFT;TOP;RIGHT;BOTTOM;LEFT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_L</inputKey>
+        <inputString>L</inputString>
+        <inputCapsLockString>l</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;LEFT;TOP;RIGHT;BOTTOM;LEFT;TOP;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_K</inputKey>
+        <inputString>K</inputString>
+        <inputCapsLockString>k</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
@@ -327,58 +372,65 @@
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;RIGHT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_O</inputKey>
+        <inputString>O</inputString>
+        <inputCapsLockString>o</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;RIGHT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_U</inputKey>
+        <inputString>U</inputString>
+        <inputCapsLockString>u</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;RIGHT;TOP;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_V</inputKey>
+        <inputString>V</inputString>
+        <inputCapsLockString>v</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;RIGHT;TOP;LEFT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_W</inputKey>
+        <inputString>W</inputString>
+        <inputCapsLockString>w</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
 
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;BOTTOM;LEFT;TOP;RIGHT;BOTTOM;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_N</inputKey>
+        <inputString>N</inputString>
+        <inputCapsLockString>n</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;BOTTOM;LEFT;TOP;RIGHT;BOTTOM;LEFT;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_M</inputKey>
+        <inputString>M</inputString>
+        <inputCapsLockString>m</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>
     </keyboardAction>
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;RIGHT;BOTTOM;LEFT;TOP;RIGHT;BOTTOM;LEFT;TOP;INSIDE_CIRCLE;</movementSequence>
-        <inputKey>KEYCODE_F</inputKey>
+        <inputString>F</inputString>
+        <inputCapsLockString>f</inputCapsLockString>
 	<flags>
 		<flag>1</flag>
 	</flags>

--- a/8vim/src/main/res/raw/sector_circle_as_buttons.xml
+++ b/8vim/src/main/res/raw/sector_circle_as_buttons.xml
@@ -14,9 +14,9 @@
 
     <!--Space-->
     <keyboardAction>
-        <keyboardActionType>INPUT_KEY</keyboardActionType>
+        <keyboardActionType>INPUT_TEXT</keyboardActionType>
         <movementSequence>INSIDE_CIRCLE;NO_TOUCH;</movementSequence>
-        <inputKey>KEYCODE_SPACE</inputKey>
+        <inputString> </inputString>
     </keyboardAction>
 
     <keyboardAction>


### PR DESCRIPTION
As mentioned in #173:

> Sending letters via circle pad thing fails to send any input. Sending numbers and symbols from the number pad does work though. I think the difference is due to the former sending KeyEvents vs text.

I changed the layout files to use `INPUT_TEXT` instead of `INPUT_KEY` and then I was able to enter text into Fabularium.

For backspace I added a method to use `inputConnection.deleteSurroundingText` which lets deletion work, but the display/cursor doesn't update until new input is entered. This is similar to Simple Keyboard. It should be possible to make it work correctly since Hacker's Keyboard is able to do that, but I'm not sure how yet. EDIT: **Turns out that Hacker's Keyboard only works correctly when completion is enabled. I guess it maintains a kind of buffer, implements the delete internally and resends the whole pending text on each keypress?**

Also, I removed the allocation in `XpadView.onMeasure` which was tripping the linter and causing the CI to fail. I'm not very familiar with Android APIs so I'm not entirely sure that I did it correctly but it seems to work... [*EDIT: hah, CI still fails due to dependency that's not the latest? seem like a silly to complain about*]