### PR TITLE
Remove ButtonKeypadView.onMeasure()

### DIFF
--- a/8vim/src/main/java/inc/flide/vim8/views/ButtonKeypadView.java
+++ b/8vim/src/main/java/inc/flide/vim8/views/ButtonKeypadView.java
@@ -59,16 +59,6 @@ public abstract class ButtonKeypadView extends KeyboardView {
         foregroundPaint.setTypeface(font);
     }
 
-    @Override
-    public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-
-        Dimension computedDimension = InputMethodViewHelper.onMeasureHelper(
-                MeasureSpec.getSize(widthMeasureSpec),
-                MeasureSpec.getSize(heightMeasureSpec),
-                getResources().getConfiguration().orientation);
-
-        setMeasuredDimension(computedDimension.getWidth(), computedDimension.getHeight());
-    }
 
     @Override
     public void onDraw(Canvas canvas) {


### PR DESCRIPTION
Fixes #181. It also seems to remove some excess space for the Pixel (1080x1920). I'm not 100% confident that there isn't some other screen dimension where this could make things worse though.


[Before: A20 (720x1560)](https://user-images.githubusercontent.com/287742/119876396-d97c5080-bef5-11eb-8372-8a29b75fae4b.png) - note the missing bottom row
[After: A20 (720x1560)](https://user-images.githubusercontent.com/287742/119876332-c5385380-bef5-11eb-9a5d-70001b9abc4e.png) - missing row restored

[Before: Pixel (1080x1920)](https://user-images.githubusercontent.com/287742/119876635-17797480-bef6-11eb-8f98-583fc04113da.png)
[After: Pixel (1080x1920)](https://user-images.githubusercontent.com/287742/119876634-17797480-bef6-11eb-8c39-3f33fe63f638.png) - note that some space at the bottom is removed compared to the before picture (this surprised me, I had to double check to make sure I didn't mix up before & after)

No apparent change for Nexus (720x1280)
[Before: Nexus (720x1280)](https://user-images.githubusercontent.com/287742/119876633-17797480-bef6-11eb-83bc-948e905436a8.png)
[After: Nexus (720x1280)](https://user-images.githubusercontent.com/287742/119876631-16e0de00-bef6-11eb-9454-d44d3cf03fff.png)

```
It causes the lowest row of buttons to be cut off on very tall
screens.
```