### PR TITLE
Make symbols, buttons and numbers react to color preference change

### DIFF
--- a/8vim/src/main/java/inc/flide/vim8/preferences/SharedPreferenceHelper.java
+++ b/8vim/src/main/java/inc/flide/vim8/preferences/SharedPreferenceHelper.java
@@ -14,7 +14,7 @@ public class SharedPreferenceHelper implements SharedPreferences.OnSharedPrefere
     private SharedPreferences sharedPreferences;
     private static SharedPreferenceHelper singleton = null;
 
-    public static interface Listener {
+    public interface Listener {
         void onPreferenceChanged();
     }
 

--- a/8vim/src/main/java/inc/flide/vim8/views/ButtonKeypadView.java
+++ b/8vim/src/main/java/inc/flide/vim8/views/ButtonKeypadView.java
@@ -8,14 +8,11 @@ import android.graphics.Typeface;
 import android.inputmethodservice.Keyboard;
 import android.inputmethodservice.KeyboardView;
 import android.util.AttributeSet;
-
 import java.util.List;
-
 import inc.flide.vim8.R;
 import inc.flide.vim8.geometry.Dimension;
 import inc.flide.vim8.keyboardHelpers.InputMethodViewHelper;
 import inc.flide.vim8.preferences.SharedPreferenceHelper;
-import inc.flide.vim8.structures.Constants;
 
 public abstract class ButtonKeypadView extends KeyboardView {
 
@@ -32,6 +29,14 @@ public abstract class ButtonKeypadView extends KeyboardView {
     }
 
     protected void initialize() {
+        //this.setOnKeyboardActionListener(new KeyboardActionListener((MainInputMethodService) context, this));
+        this.setHapticFeedbackEnabled(true);
+
+        setColors();
+        SharedPreferenceHelper.getInstance(getContext()).addListener(this::setColors);
+    }
+
+    private void setColors() {
         Resources resources = getResources();
         SharedPreferenceHelper sharedPreferenceHelper = SharedPreferenceHelper.getInstance(getContext());
 
@@ -43,15 +48,9 @@ public abstract class ButtonKeypadView extends KeyboardView {
 
         int backgroundColor = sharedPreferenceHelper.getInt(bgColorKeyId, defaultBackgroundColor);
         int foregroundColor = sharedPreferenceHelper.getInt(fgColorKeyId, defaultForegroundColor);
-
-        //this.setOnKeyboardActionListener(new KeyboardActionListener((MainInputMethodService) context, this));
-        this.setHapticFeedbackEnabled(true);
         this.setBackgroundColor(backgroundColor);
-        setupForegroundPaint(foregroundColor);
-    }
 
-    private void setupForegroundPaint(int color) {
-        foregroundPaint.setColor(color);
+        foregroundPaint.setColor(foregroundColor);
         foregroundPaint.setTextAlign(Paint.Align.CENTER);
         foregroundPaint.setTextSize(getResources().getDimensionPixelSize(R.dimen.font_size));
         Typeface font = Typeface.createFromAsset(getContext().getAssets(),
@@ -72,8 +71,7 @@ public abstract class ButtonKeypadView extends KeyboardView {
 
     @Override
     public void onDraw(Canvas canvas) {
-        List<Keyboard.Key> keys = getKeyboard().getKeys();
-        for (Keyboard.Key key : keys) {
+        for (Keyboard.Key key : getKeyboard().getKeys()) {
             if (key.label != null)
                 canvas.drawText(key.label.toString(), (key.x * 2 + key.width) / 2f, (key.y * 2 + key.height) / 2f, this.foregroundPaint);
             if (key.icon != null) {

--- a/8vim/src/main/java/inc/flide/vim8/views/NumberKeypadView.java
+++ b/8vim/src/main/java/inc/flide/vim8/views/NumberKeypadView.java
@@ -4,9 +4,9 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.inputmethodservice.Keyboard;
 import android.util.AttributeSet;
+import android.widget.Toast;
 
 import java.util.List;
-
 import inc.flide.vim8.MainInputMethodService;
 import inc.flide.vim8.R;
 import inc.flide.vim8.keyboardActionListners.ButtonKeypadActionListener;
@@ -25,18 +25,25 @@ public class NumberKeypadView extends ButtonKeypadView {
     }
 
     public void initialize(Context context) {
-        Resources resources = getResources();
-        int foregroundColor = SharedPreferenceHelper.getInstance(getContext()).getInt(
-                resources.getString(R.string.pref_board_fg_color_key),
-                resources.getColor(R.color.defaultBoardFg));
 
         MainInputMethodService mainInputMethodService = (MainInputMethodService) context;
 
         Keyboard keyboard = new Keyboard(context, R.layout.number_keypad_view);
+        setColors(keyboard);
+        this.setKeyboard(keyboard);
 
+        ButtonKeypadActionListener actionListener = new ButtonKeypadActionListener(mainInputMethodService, this);
+        this.setOnKeyboardActionListener(actionListener);
+        SharedPreferenceHelper.getInstance(getContext()).addListener(() -> setColors(keyboard));
+    }
+
+    private void setColors(Keyboard keyboard) {
+        Resources resources = getResources();
+        int foregroundColor = SharedPreferenceHelper.getInstance(getContext()).getInt(
+                resources.getString(R.string.pref_board_fg_color_key),
+                resources.getColor(R.color.defaultBoardFg));
         // Tint icon keys
-        List<Keyboard.Key> keys = keyboard.getKeys();
-        for (Keyboard.Key key : keys) {
+        for (Keyboard.Key key : keyboard.getKeys()) {
             if (key.icon != null) {
                 // Has to be mutated, otherwise icon has linked alpha to same key
                 // on xpad view
@@ -46,10 +53,6 @@ public class NumberKeypadView extends ButtonKeypadView {
                 key.icon.setAlpha(255);
             }
         }
-
-        this.setKeyboard(keyboard);
-
-        ButtonKeypadActionListener actionListener = new ButtonKeypadActionListener(mainInputMethodService, this);
-        this.setOnKeyboardActionListener(actionListener);
+        invalidate();
     }
 }

--- a/8vim/src/main/java/inc/flide/vim8/views/SymbolKeypadView.java
+++ b/8vim/src/main/java/inc/flide/vim8/views/SymbolKeypadView.java
@@ -4,9 +4,6 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.inputmethodservice.Keyboard;
 import android.util.AttributeSet;
-
-import java.util.List;
-
 import inc.flide.vim8.MainInputMethodService;
 import inc.flide.vim8.R;
 import inc.flide.vim8.keyboardActionListners.ButtonKeypadActionListener;
@@ -14,9 +11,7 @@ import inc.flide.vim8.preferences.SharedPreferenceHelper;
 
 public class SymbolKeypadView extends ButtonKeypadView {
 
-
     public SymbolKeypadView(Context context, AttributeSet attrs) {
-
         super(context, attrs);
         initialize(context);
     }
@@ -27,18 +22,26 @@ public class SymbolKeypadView extends ButtonKeypadView {
     }
 
     public void initialize(Context context) {
+        MainInputMethodService mainInputMethodService = (MainInputMethodService) context;
+
+        Keyboard keyboard = new Keyboard(context, R.layout.symbols_keypad_view);
+        setColors(keyboard);
+        this.setKeyboard(keyboard);
+
+        ButtonKeypadActionListener actionListener = new ButtonKeypadActionListener(mainInputMethodService, this);
+        this.setOnKeyboardActionListener(actionListener);
+
+        SharedPreferenceHelper.getInstance(context).addListener(() -> setColors(keyboard));
+    }
+
+    private void setColors(Keyboard keyboard) {
         Resources resources = getResources();
         int foregroundColor = SharedPreferenceHelper.getInstance(getContext()).getInt(
                 resources.getString(R.string.pref_board_fg_color_key),
                 resources.getColor(R.color.defaultBoardFg));
 
-        MainInputMethodService mainInputMethodService = (MainInputMethodService) context;
-
-        Keyboard keyboard = new Keyboard(context, R.layout.symbols_keypad_view);
-
         // Tint icon keys
-        List<Keyboard.Key> keys = keyboard.getKeys();
-        for (Keyboard.Key key : keys) {
+        for (Keyboard.Key key : keyboard.getKeys()) {
             if (key.icon != null) {
                 // Has to be mutated, otherwise icon has linked alpha to same key
                 // on xpad view
@@ -47,9 +50,7 @@ public class SymbolKeypadView extends ButtonKeypadView {
                 key.icon.setAlpha(255);
             }
         }
-        this.setKeyboard(keyboard);
 
-        ButtonKeypadActionListener actionListener = new ButtonKeypadActionListener(mainInputMethodService, this);
-        this.setOnKeyboardActionListener(actionListener);
+        invalidate();
     }
 }


### PR DESCRIPTION
Changing the current foreground/background color preference doesn't update the symbol/number views until you change the default IME from 8VIM to another and back. This PR makes the changes immediate.

https://user-images.githubusercontent.com/2689445/123859846-04353c80-d8da-11eb-8531-2231276d59d0.mp4

https://user-images.githubusercontent.com/2689445/123860018-3b0b5280-d8da-11eb-8527-c3d0c6174a54.mp4 



