### PR TITLE
Change Italian layout

### DIFF
--- a/8vim/src/main/res/raw/it_regular_italian.xml
+++ b/8vim/src/main/res/raw/it_regular_italian.xml
@@ -548,8 +548,8 @@
         <keyboardAction>
             <keyboardActionType>INPUT_TEXT</keyboardActionType>
             <movementSequence>INSIDE_CIRCLE;LEFT;BOTTOM;LEFT;TOP;INSIDE_CIRCLE;</movementSequence>
-            <inputString>î</inputString>
-            <inputCapsLockString>Î</inputCapsLockString>
+            <inputString>í</inputString>
+            <inputCapsLockString>Í</inputCapsLockString>
         </keyboardAction>
         <keyboardAction>
             <keyboardActionType>INPUT_TEXT</keyboardActionType>


### PR DESCRIPTION
Letter Î is never used in Italian language, while letter Í is sometimes (quite rarely) used.