### PR TITLE
Use static list instead of R.raw.class.getFields()

### DIFF
--- a/8vim/src/main/java/inc/flide/vim8/ui/SettingsFragment.java
+++ b/8vim/src/main/java/inc/flide/vim8/ui/SettingsFragment.java
@@ -158,9 +158,9 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
     private Map<String, String> findAllAvailableLayouts() {
         Map<String, String> languagesAndLayouts = new TreeMap<>();
-        Field[] fields = R.raw.class.getFields();
+        String[] fields = getResources().getStringArray(R.array.keyboard_layouts_id);
         for (int count = 0; count < fields.length; count++) {
-            LayoutFileName file = new LayoutFileName(fields[count].getName());
+            LayoutFileName file = new LayoutFileName(fields[count]);
             if (file.isValidLayout()) {
                 languagesAndLayouts.put(file.getLayoutDisplayName(), file.getResourceName());
             }

--- a/8vim/src/main/java/inc/flide/vim8/ui/SettingsFragment.java
+++ b/8vim/src/main/java/inc/flide/vim8/ui/SettingsFragment.java
@@ -17,7 +17,6 @@ import androidx.preference.SeekBarPreference;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/8vim/src/main/res/values/strings.xml
+++ b/8vim/src/main/res/values/strings.xml
@@ -20,6 +20,39 @@
     <string name="share_app">Share &appname;</string>
     <string name="select_preferred_emoticon_keyboard_dialog_title">Choose the input method</string>
     <string name="select_preferred_keyboard_layout_dialog_title">Choose the diacritics</string>
+    <string-array name="keyboard_layouts_id">
+        <item>af_regular_afrikaans</item>
+        <item>br_regular_breton</item>
+        <item>bs_regular_bosnian</item>
+        <item>ca_regular_catalan</item>
+        <item>cz_regular_czech</item>
+        <item>da_regular_danish</item>
+        <item>de_regular_german</item>
+        <item>dk_regular_danish</item>
+        <item>en_regular_8pen</item>
+        <item>eo_regular_esperanto</item>
+        <item>es_regular_spanish</item>
+        <item>fi_regular_finnish</item>
+        <item>fo_regular_faroese</item>
+        <item>fr_regular_french</item>
+        <item>ga_regular_irish</item>
+        <item>he_regular_hebrew</item>
+        <item>hr_regular_croatian</item>
+        <item>hu_regular_hungarian</item>
+        <item>is_regular_islandic</item>
+        <item>it_regular_italian</item>
+        <item>lt_regular_lithuanian</item>
+        <item>lv_regular_latvian</item>
+        <item>nl_regular_dutch</item>
+        <item>no_regular_norwegian</item>
+        <item>pl_regular_polish</item>
+        <item>pt_regular_portuguese</item>
+        <item>sk_regular_slovak</item>
+        <item>sq_regular_albanian</item>
+        <item>sr_regular_serbian</item>
+        <item>sv_regular_swedish</item>
+        <item>tr_regular_turkish</item>
+    </string-array>
     <string name="select_custom_keyboard_layout_dialog_title">Load the layout file from disk</string>
     <string name="generic_okay_text">OK</string>
     <string name="generic_cancel_text">Cancel</string>


### PR DESCRIPTION
Fixes #238.

Could reproduce that the menu was empty when I compiled it myself without this change and that the problem was gone after it.