### PR TITLE
🚀 feat(NumberKeypadView.java): Dynamic currency symbol on Number pad

### DIFF
--- a/8vim/src/main/java/inc/flide/vim8/views/NumberKeypadView.java
+++ b/8vim/src/main/java/inc/flide/vim8/views/NumberKeypadView.java
@@ -5,6 +5,9 @@ import android.content.res.Resources;
 import android.inputmethodservice.Keyboard;
 import android.util.AttributeSet;
 
+import java.util.Currency;
+import java.util.Locale;
+
 import inc.flide.vim8.MainInputMethodService;
 import inc.flide.vim8.R;
 import inc.flide.vim8.keyboardActionListners.ButtonKeypadActionListener;
@@ -23,16 +26,26 @@ public class NumberKeypadView extends ButtonKeypadView {
     }
 
     public void initialize(Context context) {
-
         MainInputMethodService mainInputMethodService = (MainInputMethodService) context;
 
         Keyboard keyboard = new Keyboard(context, R.layout.number_keypad_view);
+        setCurrencySymbolBasedOnLocale(keyboard);
         setColors(keyboard);
         this.setKeyboard(keyboard);
 
         ButtonKeypadActionListener actionListener = new ButtonKeypadActionListener(mainInputMethodService, this);
         this.setOnKeyboardActionListener(actionListener);
         SharedPreferenceHelper.getInstance(getContext()).addListener(() -> setColors(keyboard));
+    }
+
+    private void setCurrencySymbolBasedOnLocale(Keyboard keyboard) {
+        for (Keyboard.Key key: keyboard.getKeys()) {
+            if(key.label != null && key.label.toString().equals(getResources().getString(R.string.currencySymbol))) {
+            Currency currency = Currency.getInstance(Locale.getDefault());
+            key.label = currency.getSymbol();
+            key.text = currency.getSymbol();
+            }
+        }
     }
 
     private void setColors(Keyboard keyboard) {

--- a/8vim/src/main/res/layout/number_keypad_view.xml
+++ b/8vim/src/main/res/layout/number_keypad_view.xml
@@ -13,9 +13,8 @@
             android:keyWidth="25%p"
             android:keyEdgeFlags="left" />
         <Key
-            android:keyOutputText="@string/rupeeSymbol"
             android:isRepeatable="true"
-            android:keyLabel="@string/rupeeSymbol"
+            android:keyLabel="@string/currencySymbol"
             android:keyWidth="25%p"/>
         <Key
             android:keyOutputText="&amp;"

--- a/8vim/src/main/res/values/keyIcons.xml
+++ b/8vim/src/main/res/values/keyIcons.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="spaceBarSymbol">&#x2517;&#x2501;&#x251B;</string>
     <string name="symbolPadIcon">&#x007C;{^$&#x007C;</string>
-    <string name="rupeeSymbol">&#x20B9;</string>
+    <string name="currencySymbol">currencySymbol</string>
     <string name="poundSign">&#x00A3;</string>
     <string name="euroSign">&#x20AC;</string>
     <string name="copyrightSign">&#x00A9;</string>


### PR DESCRIPTION
This adds support for displaying the currency symbol on the number keypad view. The currency symbol is now displayed based on the user's locale. The currency symbol is set in the `setCurrencySymbolBasedOnLocale` method. The `rupeeSymbol` string resource has been renamed to `currencySymbol` to make it more generic.
Resolve #279 