### PR TITLE
fix: incorrect height for layouts

### DIFF
--- a/8vim/src/main/res/layout/number_keypad_view.xml
+++ b/8vim/src/main/res/layout/number_keypad_view.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:keyWidth="20%p"
-    android:keyHeight="12%p">
+    android:keyHeight="8%p">
 
     <Row>
 

--- a/8vim/src/main/res/layout/selection_keypad_view.xml
+++ b/8vim/src/main/res/layout/selection_keypad_view.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:keyWidth="20%p"
-    android:keyHeight="12%p">
+    android:keyHeight="10%p">
 
     <Row>
 

--- a/8vim/src/main/res/layout/symbols_keypad_view.xml
+++ b/8vim/src/main/res/layout/symbols_keypad_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
     android:keyWidth="20%p"
-    android:keyHeight="9%p"
+    android:keyHeight="8%p"
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 


### PR DESCRIPTION
Layouts for numbers/symbols/controls should be rendered properly

![Screenshot_20230606_000148](https://github.com/flide/8VIM/assets/25067710/468abd89-37b4-42b1-bdb0-b87ad1f981a8)
![Screenshot_20230606_000133](https://github.com/flide/8VIM/assets/25067710/abd0234c-ebe8-4ea4-90e4-9a379c69ede3)
![Screenshot_20230606_000110](https://github.com/flide/8VIM/assets/25067710/729717bb-b28e-4592-9d95-922f390b7812)
