### PR TITLE
fix: make jackson library compatible for older android version

### DIFF
--- a/8vim/build.gradle
+++ b/8vim/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:${rootProject.androidXConstraintlayoutVersion}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${rootProject.androidXLifecycleViewmodelVersion}"
     implementation "androidx.preference:preference:${rootProject.androidXPreferenceVersion}"
+    //noinspection GradleDependency
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${rootProject.jacksonYamlVersion}"
     implementation "com.github.kizitonwose.colorpreference:support:${rootProject.colorPreferenceVersion}"
     implementation "com.google.android.material:material:${rootProject.androidMaterialVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ ext {
     assertJVersion = "3.24.2"
     colorPreferenceVersion = "1.1.0"
     espressoVersion = "3.5.1"
-    jacksonYamlVersion = "2.14.2"
+    jacksonYamlVersion = "2.13.5"
     jqwikVersion = "1.7.3"
     junit4Version = "4.13.2"
     junit5Version = "5.9.3"


### PR DESCRIPTION
Jackson 2.14 is only compatible from Android API 26 (Android 8.0). Downgrading it to 2.13 make it compatible with older version