### PR TITLE
Fixing and changing the Ukrainian layout

### DIFF
--- a/8vim/src/main/res/raw/uk.yaml
+++ b/8vim/src/main/res/raw/uk.yaml
@@ -4,9 +4,9 @@ layers:
       right:
         parts:
           top:
-            - lower_case: a
+            - lower_case: а
             - lower_case: ь
-            - lower_case: x
+            - lower_case: х
             - lower_case: "?"
               upper_case: "*"
           bottom:
@@ -23,7 +23,7 @@ layers:
             - lower_case: б
             - lower_case: ц
           left:
-            - lower_case: p
+            - lower_case: р
             - lower_case: д
             - lower_case: г
             - lower_case: ґ
@@ -36,7 +36,7 @@ layers:
             - lower_case: .
               upper_case: "-"
           bottom:
-            - lower_case: i
+            - lower_case: і
             - lower_case: п
             - lower_case: ч
             - lower_case: ","
@@ -46,12 +46,12 @@ layers:
           left:
             - lower_case: в
             - lower_case: л
-            - lower_case: e
+            - lower_case: е
             - lower_case: "@"
               upper_case: "@gmail.com"
           right:
-            - lower_case: o
-            - lower_case: y
+            - lower_case: о
+            - lower_case: у
             - lower_case: л
             - lower_case: ф
   extra_layers:

--- a/8vim/src/main/res/raw/uk.yaml
+++ b/8vim/src/main/res/raw/uk.yaml
@@ -52,7 +52,7 @@ layers:
           right:
             - lower_case: о
             - lower_case: у
-            - lower_case: л
+            - lower_case: ш
             - lower_case: ф
   extra_layers:
     first:
@@ -78,6 +78,7 @@ layers:
             right:
               - null
               - lower_case: ю
+              - lower_case: щ
     second:
       sectors:
         right:

--- a/8vim/src/main/res/raw/uk.yaml
+++ b/8vim/src/main/res/raw/uk.yaml
@@ -26,7 +26,8 @@ layers:
             - lower_case: р
             - lower_case: д
             - lower_case: г
-            - lower_case: ґ
+            - lower_case: "'"
+              upper_case: '"'
       left:
         parts:
           top:
@@ -65,6 +66,10 @@ layers:
           parts:
             right:
               - lower_case: й
+            left:
+              - null
+              - null
+              - lower_case: ґ
         left:
           parts:
             bottom:


### PR DESCRIPTION
- Fixed incorrect characters: a, x, p, i, e, o, y, written in Latin letters, to Cyrillic letters: а, х, р, і, е, о, у, respectively.
- Added the letters "ш" and "щ".
- Moved the letter "ґ" to the 2nd layer. Instead, the 1st layer contains quotes, like in the English layout.