### PR TITLE
fix: Removed (the now defunct) 8vim website from app.

### DIFF
--- a/8vim/src/main/java/inc/flide/vim8/ui/AboutUsActivity.java
+++ b/8vim/src/main/java/inc/flide/vim8/ui/AboutUsActivity.java
@@ -17,7 +17,6 @@ public class AboutUsActivity extends AppCompatActivity {
 
         setupLink(R.id.constraintLayout_github, "https://github.com/flide/8vim");
         setupLink(R.id.constraintLayout_matrix, "https://app.element.io/#/room/#8vim/lobby:matrix.org");
-        setupLink(R.id.constraintLayout_website, "https://8vim.com");
         setupLink(R.id.constraintLayout_twitter, "https://twitter.com/8vim_?s=09");
         setupLink(R.id.constraintLayout_playstore, "https://play.google.com/store/apps/details?id=inc.flide.vi8");
         setupBackArrow();

--- a/8vim/src/main/res/layout/about_us_activity_layout.xml
+++ b/8vim/src/main/res/layout/about_us_activity_layout.xml
@@ -10,7 +10,9 @@
         android:id="@+id/constraintLayout_outer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:padding="@dimen/activity_vertical_margin">
+        android:padding="@dimen/activity_vertical_margin"
+        tools:layout_editor_absoluteX="16dp"
+        tools:layout_editor_absoluteY="-85dp">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/constraintLayout_aboutus"
@@ -357,62 +359,6 @@
                         app:layout_constraintTop_toTopOf="parent"
                         app:layout_constraintVertical_bias="0.478"
                         tools:layout_editor_absoluteX="200sp" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/constraintLayout14"
-                    android:layout_width="match_parent"
-                    android:layout_height="0.5sp"
-                    android:layout_marginTop="5sp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/constraintLayout_matrix">
-
-                    <com.google.android.material.divider.MaterialDivider
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/constraintLayout_website"
-                    android:layout_width="match_parent"
-                    android:layout_height="35sp"
-                    android:layout_marginTop="5sp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/constraintLayout14">
-
-                    <ImageView
-                        android:id="@+id/imageView2"
-                        android:layout_width="15sp"
-                        android:layout_height="15sp"
-                        android:layout_marginStart="4sp"
-                        android:contentDescription="@string/website_icon_content_description"
-                        android:src="@drawable/link_vd_vector"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toStartOf="@+id/textView5"
-                        app:layout_constraintHorizontal_bias="0.065"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintVertical_bias="0.481" />
-
-                    <TextView
-                        android:id="@+id/textView5"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="45sp"
-                        android:text="@string/connect_using_website_label"
-                        android:textSize="15sp"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintLeft_toLeftOf="@+id/constraintLayout_website"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintVertical_bias="0.478"
-                        tools:layout_editor_absoluteX="192sp" />
-
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
I noticed that the 8vim.com site now points to a scam site. So I figured it is very important that it is not listed in the app. I know it is a small change, but I hope it will be helpful none the less.

By the way, this is my first pull request, so if I did anything wrong, or stupid, please let me know and I will be better in the future.

I verified that 8vim.com was not listed anywhere in the code via the command:
```
grep 8vim.com -R .
```
So hopefully there are no more references to the website in the code.

EDIT: added refs:

refs: #244 