### PR TITLE
fix: 🐛 app crashing due to proguard rule

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - run: echo OK
   build:
-    if: ${{ !cancelled() && (needs.test_check.result == 'success' || needs.validate_layouts.result == 'success') }}
+    if: ${{ !cancelled() && (needs.test_check.result != 'failure' && needs.validate_layouts.result != 'failure') }}
     needs: [validate_layouts, test_check]
     uses: ./.github/workflows/build.yaml
     with:
@@ -76,7 +76,7 @@ jobs:
       target: debug
     secrets: inherit
   upload_artifact:
-    if: ${{ !cancelled() && needs.build.result=='success' }}
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     needs: [build]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -55,15 +55,21 @@ jobs:
           json_schema: ./8vim/src/main/resources/schema.json
           yaml_as_json: "true"
           base_dir: ./8vim/src/main/res/raw
-  test:
+  test_run:
     name: 8VIM tests
     needs: changes
     if: ${{ needs.changes.outputs.src == 'true' }}
     uses: ./.github/workflows/codecheck.yaml
     secrets: inherit
+  test_check:
+    name: Github action test check workaround
+    needs: test_run
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo OK
   build:
-    if: ${{ !cancelled() && (needs.test.result == 'success' || needs.validate_layouts.result == 'success') }}
-    needs: [validate_layouts, test]
+    if: ${{ !cancelled() && (needs.test_check.result == 'success' || needs.validate_layouts.result == 'success') }}
+    needs: [validate_layouts, test_check]
     uses: ./.github/workflows/build.yaml
     with:
       ref: ${{github.ref}}

--- a/8vim/build.gradle.kts
+++ b/8vim/build.gradle.kts
@@ -35,7 +35,7 @@ android {
     val versionRc = (versionProps["RC"] as String).toInt()
 
     namespace = "inc.flide.vim8"
-    compileSdk = 33
+    compileSdk = 34
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -54,7 +54,7 @@ android {
     defaultConfig {
         applicationId = "inc.flide.vi8"
         minSdk = 24
-        targetSdk = 33
+        targetSdk = 34
 
         val rcValue = if (versionRc > 0) 100 - versionRc else 0
         versionCode =

--- a/8vim/build.gradle.kts
+++ b/8vim/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.mannodermaus.android.junit5)
+    alias(libs.plugins.mikepenz.aboutlibraries)
     checkstyle
     jacoco
 }
@@ -71,11 +72,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    bundle {
-        language {
-            enableSplit = false
-        }
-    }
+    bundle.language.enableSplit = false
 
     buildFeatures {
         compose = true
@@ -97,7 +94,16 @@ android {
     }
 
     buildTypes {
-        release {
+        named("debug") {
+            isDebuggable = true
+
+            /* Activate R8 in debug mode, good to check if any new library added works
+            isMinifyEnabled = true
+            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            */
+        }
+
+        named("release") {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
             if (System.getenv("VIM8_BUILD_KEYSTORE_FILE") != null) {
@@ -183,8 +189,10 @@ dependencies {
     implementation(libs.jackson.module.kotlin)
     implementation(libs.json.schema.validator)
     implementation(libs.keyboardview)
-//    implementation(libs.kotlinx.coroutines)
+    implementation(libs.kotlin.reflect)
     implementation(libs.logback.android)
+    implementation(libs.mikepenz.aboutlibraries.core)
+    implementation(libs.mikepenz.aboutlibraries.compose)
     implementation(libs.slf4j.api)
 
     ksp(libs.arrow.ksp)
@@ -196,11 +204,9 @@ dependencies {
     androidTestImplementation(libs.junit4)
 
     testImplementation(libs.logback.classic)
-    testImplementation(libs.assertj.core)
     testImplementation(libs.junit5.api)
     testRuntimeOnly(libs.junit5.jupiter.engine)
     testRuntimeOnly(libs.junit5.vintage.engine)
-    testImplementation(libs.jqwik)
     testImplementation(libs.kotest.assertions)
     testImplementation(libs.kotest.extensions.arrow)
     testImplementation(libs.kotest.framework.datatest)

--- a/8vim/proguard-rules.pro
+++ b/8vim/proguard-rules.pro
@@ -1,41 +1,27 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /home/flide/Programming/Android/adt_linux/sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+-keepattributes Synthetic,Signature,*Annotation*,EnclosingMethod,InnerClasses
 
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-# Proguard configuration for Jackson 2.x
--keepattributes *Annotation*,EnclosingMethod,Signature
--keep class com.fasterxml.jackson.databind.ObjectMapper {
-    public <methods>;
-    protected <methods>;
-}
--keepnames class com.fasterxml.jackson.** { *; }
+-keep class com.fasterxml.jackson.** {*; }
 -keep class com.networknt.schema.** { *; }
--dontwarn org.jcodings.Encoding
--dontwarn org.jcodings.specific.UTF8Encoding
--dontwarn org.joni.Matcher
--dontwarn org.joni.Regex
--dontwarn org.joni.Syntax
--dontwarn org.joni.exception.SyntaxException
+
+-dontwarn org.jcodings.**
+-dontwarn org.joni.**
 -dontwarn com.fasterxml.jackson.databind.**
--keep public class inc.flide.vim8.structures.** {
-    *;
-}
+
+-keep,allowobfuscation,allowshrinking class arrow.core.Either
+-keep,allowobfuscation,allowshrinking class arrow.core.Option
+
+-keep class inc.flide.vim8.models.** { *; }
+-keep class inc.flide.vim8.ime.KeyboardDataYamlParser* { *; }
+
+-keep class ch.qos.logback.** { *; }
 -keepclassmembers class ch.qos.logback.classic.pattern.* { <init>(); }
 -keepclassmembers class ch.qos.logback.** { *; }
 -keepclassmembers class org.slf4j.impl.** { *; }
 -dontwarn ch.qos.logback.core.net.*
 -keep class kotlin.Metadata { *; }
 -keep class kotlin.reflect.** { *; }
+
+-keep class inc.flide.vim8.R
+-keep class inc.flide.vim8.R$* {
+    <fields>;
+}

--- a/8vim/src/main/java/inc/flide/vim8/keyboardactionlisteners/MainKeypadActionListener.java
+++ b/8vim/src/main/java/inc/flide/vim8/keyboardactionlisteners/MainKeypadActionListener.java
@@ -8,6 +8,7 @@ import inc.flide.vim8.models.FingerPosition;
 import inc.flide.vim8.models.KeyboardAction;
 import inc.flide.vim8.models.KeyboardActionType;
 import inc.flide.vim8.models.KeyboardData;
+import inc.flide.vim8.models.KeyboardDataKt;
 import inc.flide.vim8.models.LayerLevel;
 import inc.flide.vim8.models.MovementSequenceType;
 import inc.flide.vim8.models.yaml.ExtraLayer;
@@ -83,11 +84,11 @@ public class MainKeypadActionListener extends KeypadActionListener {
     }
 
     public String getLowerCaseCharacters(LayerLevel layer) {
-        return keyboardData.lowerCaseCharacters(layer).getOrNull();
+        return KeyboardDataKt.lowerCaseCharacters(keyboardData, layer).getOrNull();
     }
 
     public String getUpperCaseCharacters(LayerLevel layer) {
-        return keyboardData.upperCaseCharacters(layer).getOrNull();
+        return KeyboardDataKt.upperCaseCharacters(keyboardData, layer).getOrNull();
     }
 
     public String getCurrentLetter() {
@@ -114,7 +115,7 @@ public class MainKeypadActionListener extends KeypadActionListener {
         }
         List<FingerPosition> tempMovementSequence = new ArrayList<>(movementSequence);
         tempMovementSequence.add(FingerPosition.INSIDE_CIRCLE);
-        return keyboardData.findLayer(tempMovementSequence);
+        return KeyboardDataKt.findLayer(keyboardData, tempMovementSequence);
     }
 
     private boolean isFullRotation() {

--- a/8vim/src/main/kotlin/inc/flide/vim8/ime/InputMethodServiceHelper.kt
+++ b/8vim/src/main/kotlin/inc/flide/vim8/ime/InputMethodServiceHelper.kt
@@ -13,9 +13,14 @@ import inc.flide.vim8.models.FingerPosition
 import inc.flide.vim8.models.KeyboardAction
 import inc.flide.vim8.models.KeyboardData
 import inc.flide.vim8.models.LayerLevel
+import inc.flide.vim8.models.addAllToActionMap
 import inc.flide.vim8.models.error.ExceptionWrapperError
 import inc.flide.vim8.models.error.LayoutError
 import inc.flide.vim8.models.info
+import inc.flide.vim8.models.lowerCaseCharacters
+import inc.flide.vim8.models.setLowerCaseCharacters
+import inc.flide.vim8.models.setUpperCaseCharacters
+import inc.flide.vim8.models.upperCaseCharacters
 import java.io.InputStream
 
 object InputMethodServiceHelper {
@@ -43,7 +48,7 @@ object InputMethodServiceHelper {
 
     private fun getLayoutIndependentKeyboardData(resources: Resources): KeyboardData {
         if (layoutIndependentKeyboardData == null) {
-            layoutIndependentKeyboardData = either {
+            val m = either {
                 val layoutIndependentKeyboardData = KeyboardData()
                 val sectorCircleButtonsKeyboard = addToKeyboardActionsMapUsingResourceId(
                     layoutIndependentKeyboardData,
@@ -60,6 +65,11 @@ object InputMethodServiceHelper {
                     resources,
                     R.raw.special_core_gestures
                 ).bind()
+            }
+            layoutIndependentKeyboardData = m.onLeft {
+                if (it is ExceptionWrapperError) {
+                    it.exception.printStackTrace()
+                }
             }.getOrNull()
         }
         return layoutIndependentKeyboardData!!

--- a/8vim/src/main/kotlin/inc/flide/vim8/models/CharacterSet.kt
+++ b/8vim/src/main/kotlin/inc/flide/vim8/models/CharacterSet.kt
@@ -8,6 +8,7 @@ data class CharacterSet(
     val upperCaseCharacters: String = ""
 ) {
     companion object
-
-    fun isNotEmpty(): Boolean = lowerCaseCharacters.isNotEmpty() || upperCaseCharacters.isNotEmpty()
 }
+
+fun CharacterSet.isNotEmpty(): Boolean =
+    lowerCaseCharacters.isNotEmpty() || upperCaseCharacters.isNotEmpty()

--- a/8vim/src/main/kotlin/inc/flide/vim8/models/KeyboardData.kt
+++ b/8vim/src/main/kotlin/inc/flide/vim8/models/KeyboardData.kt
@@ -1,6 +1,7 @@
 package inc.flide.vim8.models
 
 import arrow.core.Option
+import arrow.core.elementAtOrNone
 import arrow.core.none
 import arrow.core.some
 import arrow.optics.dsl.index
@@ -22,58 +23,6 @@ data class KeyboardData(
         .indexOfLast { it.isNotEmpty() }
         .let { if (it == -1) 0 else it + 1 }
 
-    fun addAllToActionMap(actionMapAddition: Map<MovementSequence, KeyboardAction>): KeyboardData {
-        return KeyboardData.actionMap.modify(this) {
-            it + actionMapAddition
-        }
-    }
-
-    fun lowerCaseCharacters(layer: LayerLevel): Option<String> {
-        return Option.fromNullable(
-            KeyboardData.characterSets.index(
-                Index.list(),
-                layer.ordinal - 1
-            ).lowerCaseCharacters.getOrNull(
-                this
-            )
-        ).flatMap { if (it.isEmpty()) none() else it.some() }
-    }
-
-    fun upperCaseCharacters(layer: LayerLevel): Option<String> {
-        return Option.fromNullable(
-            KeyboardData.characterSets.index(
-                Index.list(),
-                layer.ordinal - 1
-            ).upperCaseCharacters.getOrNull(
-                this
-            )
-        ).flatMap { if (it.isEmpty()) none() else it.some() }
-    }
-
-    fun setLowerCaseCharacters(lowerCaseCharacters: String, layer: LayerLevel): KeyboardData {
-        return KeyboardData.characterSets.index(
-            Index.list(),
-            layer.ordinal - 1
-        ).lowerCaseCharacters.set(
-            this,
-            lowerCaseCharacters
-        )
-    }
-
-    fun setUpperCaseCharacters(upperCaseCharacters: String, layer: LayerLevel): KeyboardData {
-        return KeyboardData.characterSets.index(
-            Index.list(),
-            layer.ordinal - 1
-        ).upperCaseCharacters.set(
-            this,
-            upperCaseCharacters
-        )
-    }
-
-    fun findLayer(movementSequence: MovementSequence): LayerLevel {
-        return actionMap[movementSequence]?.layer ?: LayerLevel.FIRST
-    }
-
     override fun toString(): String {
         val sb = StringBuilder(info.name)
         if (totalLayers > 1) {
@@ -83,4 +32,62 @@ data class KeyboardData(
         }
         return sb.toString()
     }
+}
+
+fun KeyboardData.addAllToActionMap(
+    actionMapAddition: Map<MovementSequence, KeyboardAction>
+): KeyboardData {
+    return KeyboardData.actionMap.modify(this) {
+        it + actionMapAddition
+    }
+}
+
+fun KeyboardData.lowerCaseCharacters(layer: LayerLevel): Option<String> {
+    return characterSets.elementAtOrNone(layer.ordinal - 1).flatMap {
+        if (it.lowerCaseCharacters.isEmpty()) {
+            none()
+        } else {
+            it.lowerCaseCharacters.some()
+        }
+    }
+}
+
+fun KeyboardData.upperCaseCharacters(layer: LayerLevel): Option<String> {
+    return characterSets.elementAtOrNone(layer.ordinal - 1).flatMap {
+        if (it.upperCaseCharacters.isEmpty()) {
+            none()
+        } else {
+            it.upperCaseCharacters.some()
+        }
+    }
+}
+
+fun KeyboardData.setLowerCaseCharacters(
+    lowerCaseCharacters: String,
+    layer: LayerLevel
+): KeyboardData {
+    return KeyboardData.characterSets.index(
+        Index.list(),
+        layer.ordinal - 1
+    ).lowerCaseCharacters.set(
+        this,
+        lowerCaseCharacters
+    )
+}
+
+fun KeyboardData.setUpperCaseCharacters(
+    upperCaseCharacters: String,
+    layer: LayerLevel
+): KeyboardData {
+    return KeyboardData.characterSets.index(
+        Index.list(),
+        layer.ordinal - 1
+    ).upperCaseCharacters.set(
+        this,
+        upperCaseCharacters
+    )
+}
+
+fun KeyboardData.findLayer(movementSequence: MovementSequence): LayerLevel {
+    return actionMap[movementSequence]?.layer ?: LayerLevel.FIRST
 }

--- a/8vim/src/main/kotlin/inc/flide/vim8/models/Quadrant.kt
+++ b/8vim/src/main/kotlin/inc/flide/vim8/models/Quadrant.kt
@@ -7,36 +7,36 @@ const val NUMBER_OF_SECTORS = 4
 @optics
 data class Quadrant(val sector: Direction, val part: Direction) {
     companion object
+}
 
-    fun characterIndexInString(characterPosition: CharacterPosition): Int {
-        val index = when (sector) {
-            Direction.RIGHT -> if (part === Direction.BOTTOM) 0 else 7
-            Direction.TOP -> if (part === Direction.LEFT) 5 else 6
-            Direction.LEFT -> if (part === Direction.BOTTOM) 3 else 4
-            Direction.BOTTOM -> if (part === Direction.RIGHT) 1 else 2
-        }
-        val base = index / 2 * (NUMBER_OF_SECTORS * 2)
-        val delta = index % 2
-        return base + characterPosition.ordinal * 2 + delta
+fun Quadrant.characterIndexInString(characterPosition: CharacterPosition): Int {
+    val index = when (sector) {
+        Direction.RIGHT -> if (part === Direction.BOTTOM) 0 else 7
+        Direction.TOP -> if (part === Direction.LEFT) 5 else 6
+        Direction.LEFT -> if (part === Direction.BOTTOM) 3 else 4
+        Direction.BOTTOM -> if (part === Direction.RIGHT) 1 else 2
     }
+    val base = index / 2 * (NUMBER_OF_SECTORS * 2)
+    val delta = index % 2
+    return base + characterPosition.ordinal * 2 + delta
+}
 
-    fun opposite(position: CharacterPosition): Quadrant {
-        return when (position) {
-            CharacterPosition.FIRST -> {
-                Quadrant(sector, part.opposite())
-            }
+fun Quadrant.opposite(position: CharacterPosition): Quadrant {
+    return when (position) {
+        CharacterPosition.FIRST -> {
+            Quadrant(sector, part.opposite())
+        }
 
-            CharacterPosition.SECOND -> {
-                Quadrant(part, sector)
-            }
+        CharacterPosition.SECOND -> {
+            Quadrant(part, sector)
+        }
 
-            CharacterPosition.THIRD -> {
-                Quadrant(sector.opposite(), part)
-            }
+        CharacterPosition.THIRD -> {
+            Quadrant(sector.opposite(), part)
+        }
 
-            else -> {
-                Quadrant(part.opposite(), sector.opposite())
-            }
+        else -> {
+            Quadrant(part.opposite(), sector.opposite())
         }
     }
 }

--- a/8vim/src/main/kotlin/inc/flide/vim8/models/yaml/Layers.kt
+++ b/8vim/src/main/kotlin/inc/flide/vim8/models/yaml/Layers.kt
@@ -14,3 +14,5 @@ data class Layers(
 ) {
     companion object
 }
+
+fun Layers.hasOnlyHiddenLayer(): Boolean = extraLayers.isNotEmpty() && defaultLayer.isNone()

--- a/8vim/src/main/kotlin/inc/flide/vim8/models/yaml/Layout.kt
+++ b/8vim/src/main/kotlin/inc/flide/vim8/models/yaml/Layout.kt
@@ -1,13 +1,11 @@
 package inc.flide.vim8.models.yaml
 
-import arrow.core.Option
-import arrow.core.none
 import arrow.optics.optics
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @optics
 data class Layout(
-    @JsonProperty(required = true) val layers: Option<Layers> = none(),
+    @JsonProperty(required = true) val layers: Layers = Layers(),
     val info: LayoutInfo = LayoutInfo()
 ) {
     companion object

--- a/8vim/src/test/kotlin/inc/flide/vim8/geometry/CircleSpec.kt
+++ b/8vim/src/test/kotlin/inc/flide/vim8/geometry/CircleSpec.kt
@@ -19,6 +19,10 @@ class CircleSpec : FunSpec({
     }
     context("get sector from a point") {
         withData(
+            nameFn = {
+                "Finger at (${it.second.x}, ${it.second.y})" +
+                    "should be the ${it.first} sector"
+            },
             (FingerPosition.TOP to mockPointF(0f, -10f)),
             (FingerPosition.LEFT to mockPointF(-10f, 0f)),
             (FingerPosition.BOTTOM to mockPointF(0f, 10f)),

--- a/8vim/src/test/kotlin/inc/flide/vim8/ime/KeyboardDataYamlParserTest.kt
+++ b/8vim/src/test/kotlin/inc/flide/vim8/ime/KeyboardDataYamlParserTest.kt
@@ -8,6 +8,8 @@ import inc.flide.vim8.models.FingerPosition
 import inc.flide.vim8.models.KeyboardAction
 import inc.flide.vim8.models.KeyboardActionType
 import inc.flide.vim8.models.LayerLevel
+import inc.flide.vim8.models.lowerCaseCharacters
+import inc.flide.vim8.models.upperCaseCharacters
 import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.assertions.arrow.core.shouldBeSome

--- a/8vim/src/test/kotlin/inc/flide/vim8/models/DirectionSpec.kt
+++ b/8vim/src/test/kotlin/inc/flide/vim8/models/DirectionSpec.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 class DirectionSpec : FunSpec({
     context("convert a Direction to a FingerPosition") {
         withData(
+            nameFn = { "${it.first} -> ${it.second}" },
             (Direction.RIGHT to FingerPosition.RIGHT),
             (Direction.LEFT to FingerPosition.LEFT),
             (Direction.TOP to FingerPosition.TOP),
@@ -17,6 +18,7 @@ class DirectionSpec : FunSpec({
     }
     context("get the opposite direction") {
         withData(
+            nameFn = { "${it.first} -> ${it.second}" },
             (Direction.RIGHT to Direction.LEFT),
             (Direction.LEFT to Direction.RIGHT),
             (Direction.TOP to Direction.BOTTOM),
@@ -28,6 +30,7 @@ class DirectionSpec : FunSpec({
 
     context("get a quadrant from an int") {
         withData(
+            nameFn = { "${it.first} -> ${it.second}" },
             (-1 to Direction.TOP),
             (0 to Direction.RIGHT),
             (1 to Direction.TOP),

--- a/8vim/src/test/kotlin/inc/flide/vim8/models/QuadrantSpec.kt
+++ b/8vim/src/test/kotlin/inc/flide/vim8/models/QuadrantSpec.kt
@@ -5,8 +5,9 @@ import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 
 class QuadrantSpec : FunSpec({
-    context("get index for a character set string from quadrant") {
+    context("get index for a character set string from quadrant when") {
         withData(
+            nameFn = { "${it.first.sector}/${it.first.part} should have index: ${it.second}" },
             (Quadrant(Direction.RIGHT, Direction.BOTTOM) to 0),
             (Quadrant(Direction.BOTTOM, Direction.RIGHT) to 1),
             (Quadrant(Direction.BOTTOM, Direction.LEFT) to 8),
@@ -20,9 +21,10 @@ class QuadrantSpec : FunSpec({
         }
     }
 
-    context("get opposite quadrant") {
+    context("opposite quadrant of RIGHT/BOTTOM when character position") {
         val quadrant = Quadrant(Direction.RIGHT, Direction.BOTTOM)
         withData(
+            nameFn = { "${it.first} should be ${it.second.sector}/${it.second.part}" },
             (CharacterPosition.FIRST to Quadrant(Direction.RIGHT, Direction.TOP)),
             (CharacterPosition.SECOND to Quadrant(Direction.BOTTOM, Direction.RIGHT)),
             (CharacterPosition.THIRD to Quadrant(Direction.LEFT, Direction.BOTTOM)),

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,4 +11,5 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.mannodermaus.android.junit5) apply false
+    alias(libs.plugins.mikepenz.aboutlibraries) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ androidx-lifecycle = "2.6.1"
 androidx-navigation = "2.6.0"
 androidx-preference = "1.2.1"
 android-recyclerview = "1.3.1"
-apache-commons = "1.7"
+apache-commons = "1.10.0"
 arrow = "1.2.0"
 arrow-jackson = "0.14.0"
 colorpreference = "1.1.0"
@@ -26,6 +26,7 @@ ktlint = "11.5.0"
 kotlin = "1.8.21"
 ksp = "1.8.21-1.0.11"
 logback-android = "3.0.0"
+mikepenz-aboutlibraries = "10.2.0"
 mannodermaus-android-junit5 = "1.9.3.0"
 slf4j = "2.0.7"
 
@@ -34,8 +35,6 @@ androidx-test-core = "1.5.0"
 androidx-test-ext = "1.1.5"
 androidx-test-runner = "1.5.2"
 androidx-test-espresso = "3.5.1"
-assertj = "3.24.2"
-jqwik = "1.7.3"
 junit4 = "4.13.2"
 junit5 = "5.9.3"
 kotest = "5.6.2"
@@ -70,10 +69,13 @@ jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-d
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-module-arrow-kotlin = { module = "io.arrow-kt:arrow-integrations-jackson-module", version.ref = "arrow-jackson" }
 json-schema-validator = { module = "com.networknt:json-schema-validator", version.ref = "json-schema-validator" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 logback-android = { module = "com.github.tony19:logback-android", version.ref = "logback-android" }
 keyboardview = { module = "io.github.hijamoya:keyboardview", version.ref = "keyboardview" }
 apache-commons-text = { module = "org.apache.commons:commons-text", version.ref = "apache-commons" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+mikepenz-aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "mikepenz-aboutlibraries" }
+mikepenz-aboutlibraries-compose = { module = "com.mikepenz:aboutlibraries-compose", version.ref = "mikepenz-aboutlibraries" }
 
 # Testing
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
@@ -82,8 +84,6 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-classic" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
-jqwik = { module = "net.jqwik:jqwik", version.ref = "jqwik" }
-assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 junit5-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
 junit5-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 junit5-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
@@ -107,3 +107,4 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint"}
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mannodermaus-android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "mannodermaus-android-junit5" }
+mikepenz-aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "mikepenz-aboutlibraries" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Main
 accompanist = "0.30.1"
 androidx-activity = "1.7.2"
-android-gradle-plugin = "8.1.0"
+android-gradle-plugin = "8.1.1"
 android-appcompat = "1.6.1"
 android-material = "1.9.0"
 androidx-compose = "1.4.3"


### PR DESCRIPTION
The migration to Kotlin caused the app crash to due new libraries being stripped from the package