### PR TITLE
fix: 🐛 display/crash if the layer to render is from hidden

### DIFF
--- a/8vim/src/main/kotlin/inc/flide/vim8/models/KeyboardData.kt
+++ b/8vim/src/main/kotlin/inc/flide/vim8/models/KeyboardData.kt
@@ -89,5 +89,11 @@ fun KeyboardData.setUpperCaseCharacters(
 }
 
 fun KeyboardData.findLayer(movementSequence: MovementSequence): LayerLevel {
-    return actionMap[movementSequence]?.layer ?: LayerLevel.FIRST
+    return actionMap[movementSequence]?.layer.let {
+        if (it == LayerLevel.HIDDEN) {
+            LayerLevel.FIRST
+        } else {
+            it
+        }
+    } ?: LayerLevel.FIRST
 }


### PR DESCRIPTION
If the movement sequence is from the hidden layer it should fall back to the default one

refs: #378