### PR TITLE
fix: 🐛 new layout not rendered after change

### DIFF
--- a/8vim/src/main/java/inc/flide/vim8/views/mainkeyboard/XpadView.java
+++ b/8vim/src/main/java/inc/flide/vim8/views/mainkeyboard/XpadView.java
@@ -90,6 +90,7 @@ public class XpadView extends View {
         keyboardTheme = KeyboardTheme.getInstance();
         keyboardTheme.onChange(this::updateColors);
 
+        prefs.getLayout().getCurrent().observe(newValue -> invalidate());
         AppPrefs.Keyboard.Circle circlePrefs = prefs.getKeyboard().getCircle();
         circlePrefs.getRadiusSizeFactor().observe(this::onCirclePrefsChanged);
         circlePrefs.getXCentreOffset().observe(this::onCirclePrefsChanged);


### PR DESCRIPTION
When a new layout is selected, it was rendered unless if the user interacted with the keyboard