### PR TITLE
fix: 🐛 calling wrong method

### DIFF
--- a/8vim/src/main/kotlin/inc/flide/vim8/MainInputMethodService.kt
+++ b/8vim/src/main/kotlin/inc/flide/vim8/MainInputMethodService.kt
@@ -296,7 +296,7 @@ class MainInputMethodService : InputMethodService(), ClipboardHistoryListener {
                             breakIteratorGroup.measureLastCharacters(text, 1)
                         }.coerceAtLeast(1)
                     } ?: 1
-                it.deleteSurroundingTextInCodePoints(length, 0)
+                it.deleteSurroundingText(length, 0)
             } else {
                 it.commitText("", 0)
             }


### PR DESCRIPTION
refs: #405