### PR TITLE
fix: 🐛 Extra layers not displayed

### DIFF
--- a/8vim/src/main/kotlin/inc/flide/vim8/ime/actionlisteners/MainKeypadActionListener.kt
+++ b/8vim/src/main/kotlin/inc/flide/vim8/ime/actionlisteners/MainKeypadActionListener.kt
@@ -136,7 +136,7 @@ class MainKeypadActionListener(inputMethodService: MainInputMethodService, view:
 
     override fun findLayer(): LayerLevel {
         for (i in VisibleLayers.size - 1 downTo LayerLevel.SECOND.ordinal) {
-            val layerLevel = LayerLevel.values()[i + 1]
+            val layerLevel = LayerLevel.values()[i]
             val extraLayerMovementSequence = MovementSequences[layerLevel]
                 ?: return LayerLevel.FIRST
             if (movementSequence.size < extraLayerMovementSequence.size) {


### PR DESCRIPTION
Characters on extra layers are not displayed on the keyboard

refs: #418